### PR TITLE
Remove smartpool from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ There are currently a few different methods of receiving Kovan Ether:
 * Icarus Faucet (SMS Verified, Automated)
 * ~~Github Gist Faucet ( Automated )~~ (Disallowed)
 * Request Via Gitter (Manually Verified)
-* Use PoW via [SmartPool](https://medium.com/smartpool/smartpool-alpha-release-472d60f1ef7b#.5tryckqwb)
 
 Additional, more convienient faucet services will be added in due course (e.g. [CAPTCHA / Github OAuth](https://github.com/kovan-testnet/KIPs/issues/2)).
 


### PR DESCRIPTION
1. The link in the readme is dead
1. The smartpool github states "Smartpool no longer runs on Kovan, Ropsten must be used instead." ( https://github.com/SmartPool/smartpool-client )

SmartPool is clearly not an option for getting KETH, lets remove it from the readme